### PR TITLE
call all builders' build methods to ensure a proper build

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Dist-Zilla-Plugin-CheckExtraTests
 
 {{$NEXT}}
 
+    - use all builders to build, not just the first (Karen Etheridge)
+
 0.011     2013-02-09 20:53:59 America/New_York
 
     - Doc fixes (ETHER)

--- a/lib/Dist/Zilla/App/Command/xtest.pm
+++ b/lib/Dist/Zilla/App/Command/xtest.pm
@@ -76,7 +76,7 @@ sub execute {
 
   my @builders = @{ $self->zilla->plugins_with(-BuildRunner) };
   die "no BuildRunner plugins specified" unless @builders;
-  $builders[0]->build;
+  $_->build for @builders;
 
   my $error;
 

--- a/lib/Dist/Zilla/Plugin/CheckExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/CheckExtraTests.pm
@@ -27,7 +27,7 @@ sub before_release {
   # make
   my @builders = @{ $self->zilla->plugins_with(-BuildRunner) };
   die "no BuildRunner plugins specified" unless @builders;
-  $builders[0]->build;
+  $_->build for @builders;
 
   require App::Prove;
   App::Prove->VERSION('3.00');

--- a/lib/Dist/Zilla/Plugin/RunExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/RunExtraTests.pm
@@ -29,7 +29,8 @@ sub test {
   unless (-d 'blib') {
     my @builders = @{ $self->zilla->plugins_with(-BuildRunner) };
     die "no BuildRunner plugins specified" unless @builders;
-    $builders[0]->build;
+    $_->build for @builders;
+    die "no blib; failed to build properly?" unless -d 'blib';
   }
 
   require App::Prove;


### PR DESCRIPTION
... just as with -TestRunner plugins, we should call all of them, not just the first.

(This situation arises for me when I use both [MakeMaker::Fallback] and [ModuleBuildTiny] in a dist -- the ->build sub in the former is neutered to not do anything.)

(this resolves #8.)
