### PR TITLE
accept the jobs arg coming from the test or release command

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Dist-Zilla-Plugin-CheckExtraTests
 
 {{$NEXT}}
 
+    - [RunExtraTests] now accepts the --jobs flag passed to 'dzil test' and
+      'dzil release'
+
 0.021     2014-03-25 14:34:02-04:00 America/New_York
 
     [Fixed]

--- a/lib/Dist/Zilla/Plugin/RunExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/RunExtraTests.pm
@@ -17,7 +17,7 @@ with 'Dist::Zilla::Role::TestRunner';
 # methods
 
 sub test {
-    my $self = shift;
+    my ($self, $target, $arg) = @_;
 
     my @dirs;
     push @dirs, 'xt/author'  if $ENV{AUTHOR_TESTING};
@@ -34,7 +34,11 @@ sub test {
         die "no blib; failed to build properly?" unless -d 'blib';
     }
 
-    my $jobs = $self->can('default_jobs') ? $self->default_jobs : 1;
+    my $jobs = $arg && exists $arg->{jobs}
+             ? $arg->{jobs}
+             : $self->can('default_jobs')
+             ? $self->default_jobs
+             : 1;
 
     require App::Prove;
     App::Prove->VERSION('3.00');


### PR DESCRIPTION
I noticed that "dzil test --jobs 9" wasn't working. I missed capturing the `$arg` parameter in the last PR; doh!
