### PR TITLE
avoid meta validation issues by never creating a META.yml

### DIFF
--- a/corpus/DZ/dist.ini
+++ b/corpus/DZ/dist.ini
@@ -6,14 +6,9 @@ abstract = Test Library
 copyright_holder = foobar
 copyright_year   = 2009
 
-[@Filter]
-bundle = @FakeClassic
-remove = ExtraTests
-remove = PodVersion
-remove = PodSyntaxTests
-remove = PodCoverageTests
-remove = ConfirmRelease
-remove = UploadToCPAN
+[GatherDir]
+
+[MakeMaker]
 
 [CheckExtraTests]
 

--- a/corpus/RunXT/dist.ini
+++ b/corpus/RunXT/dist.ini
@@ -6,15 +6,7 @@ abstract = Test Library
 copyright_holder = foobar
 copyright_year   = 2009
 
-[@Filter]
-bundle = @FakeClassic
-remove = ExtraTests
-remove = PodVersion
-remove = PodSyntaxTests
-remove = PodCoverageTests
-remove = ConfirmRelease
-remove = UploadToCPAN
-remove = MakeMaker
+[GatherDir]
 
 [MakeMaker::Runner]
 

--- a/corpus/WithBlib/dist.ini
+++ b/corpus/WithBlib/dist.ini
@@ -6,15 +6,7 @@ abstract = Test Library
 copyright_holder = foobar
 copyright_year   = 2009
 
-[@Filter]
-bundle = @FakeClassic
-remove = ExtraTests
-remove = PodVersion
-remove = PodSyntaxTests
-remove = PodCoverageTests
-remove = ConfirmRelease
-remove = UploadToCPAN
-remove = MakeMaker
+[GatherDir]
 
 [MakeMaker::Runner]
 


### PR DESCRIPTION
When CPAN::Meta and Dist::Zilla versions are out of sync, we can get errors like this:

```
tt/00-report-prereqs.t .. ok
[@Filter/MetaYAML] Invalid META structure.  Errors found:
[@Filter/MetaYAML] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 29 just after 1.
t/runxt.t .............. 
Dubious, test returned 29 (wstat 7424, 0x1d00)
All 1 subtests passed 
[@Filter/MetaYAML] Invalid META structure.  Errors found:
[@Filter/MetaYAML] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 29 just after 1.
t/withblib.t ........... 
Dubious, test returned 29 (wstat 7424, 0x1d00)
All 1 subtests passed 

#   Failed test 'CheckExtraTests caught xt test failure'
#   at t/checkxt.t line 39.
#                   '[@Filter/MetaYAML] Invalid META structure.  Errors found:
# [@Filter/MetaYAML] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
# '
#     doesn't match '(?^i:Fatal errors in xt)'
[@Filter/MetaYAML] Invalid META structure.  Errors found:
[@Filter/MetaYAML] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 29 just after 4.
t/checkxt.t ............ 
Dubious, test returned 29 (wstat 7424, 0x1d00)
Failed 1/4 subtests 
```

...which aren't your problem. Avoid all this by only pulling in the minimum necessary plugins in tests.
