### PR TITLE
Fix my own name in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
 Christopher J. Madsen <cjm@cpan.org> <perl@cjmweb.net>
 Jesse Luehrs <doy@cpan.org> <doy@tozt.net>
 Karen Etheridge <ether@cpan.org>
-Olivier Mengue <dolmen@cpan.org>
+Olivier Mengué <dolmen@cpan.org>
 Ricardo Signes <rjbs@cpan.org> <com.github@rjbs.manxome.org>


### PR DESCRIPTION
I'm the Unicode canary, and [Git::Contributors] is now supposed to work.