### PR TITLE
Change option order in help to match dzil help test

### DIFF
--- a/lib/Dist/Zilla/App/Command/xtest.pm
+++ b/lib/Dist/Zilla/App/Command/xtest.pm
@@ -63,12 +63,12 @@ sub opt_spec {
         { default => 1 }
       ],
       [ 'automated' => 'enables the AUTOMATED_TESTING env variable', { default => 0 } ],
-      [ 'jobs|j=i'  => 'number of parallel test jobs to run',        { default => 1 } ],
       [
         'all' =>
           'enables the RELEASE_TESTING, AUTOMATED_TESTING and AUTHOR_TESTING env variables',
         { default => 0 }
-      ];
+      ],
+      [ 'jobs|j=i'  => 'number of parallel test jobs to run',        { default => 1 } ];
 }
 
 =head1 OPTIONS


### PR DESCRIPTION
Moved —all option to where it is in the help text for test, thereby
putting all the env variable enabling options together.