### PR TITLE
Topic/no root xt files

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Dist-Zilla-Plugin-CheckExtraTests
 
 {{$NEXT}}
 
+    [Fixed]
+
+    - non-perl files in xt/* are not executed
+
 0.027     2015-05-02 15:41:56-04:00 America/New_York
 
     [Documented]

--- a/lib/Dist/Zilla/Plugin/RunExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/RunExtraTests.pm
@@ -47,6 +47,8 @@ sub test {
     App::Prove->VERSION('3.00');
 
     my $app = App::Prove->new;
+
+    $self->log_debug([ 'running prove with args: %s', join(' ', '-j', $jobs, @v, qw/-r -b/, @dirs) ]);
     $app->process_args( '-j', $jobs, @v, qw/-r -b/, @dirs );
     $app->run or $self->log_fatal("Fatal errors in xt tests");
     return;

--- a/lib/Dist/Zilla/Plugin/RunExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/RunExtraTests.pm
@@ -20,13 +20,14 @@ with 'Dist::Zilla::Role::TestRunner';
 sub test {
     my ($self, $target, $arg) = @_;
 
-    my %dirs; @dirs{ glob('xt/*') } = ();
+    my %dirs; @dirs{ grep { -d } glob('xt/*') } = ();
     delete $dirs{'xt/author'}  unless $ENV{AUTHOR_TESTING};
     delete $dirs{'xt/smoke'}   unless $ENV{AUTOMATED_TESTING};
     delete $dirs{'xt/release'} unless $ENV{RELEASE_TESTING};
 
     my @dirs = sort keys %dirs;
-    return unless @dirs;
+    my @files = grep { -f } glob('xt/*');
+    return unless @dirs or @files;
 
     # If the dist hasn't been built yet, then build it:
     unless ( -d 'blib' ) {
@@ -47,6 +48,9 @@ sub test {
     App::Prove->VERSION('3.00');
 
     my $app = App::Prove->new;
+
+    $self->log_debug([ 'running prove with args: %s', join(' ', '-j', $jobs, @v, qw/-b xt/) ]);
+    $app->process_args( '-j', $jobs, @v, qw/-b xt/);
 
     $self->log_debug([ 'running prove with args: %s', join(' ', '-j', $jobs, @v, qw/-r -b/, @dirs) ]);
     $app->process_args( '-j', $jobs, @v, qw/-r -b/, @dirs );

--- a/t/runxt.t
+++ b/t/runxt.t
@@ -27,7 +27,14 @@ local $ENV{AUTOMATED_TESTING};
     );
     ok( $tzil, "created test dist" );
 
-    capture { $tzil->test };
+    try {
+        capture { $tzil->test };
+    }
+    catch {
+        my $err = $_;
+        fail( $err );
+        diag 'got log messages: ', explain $tzil->log_messages;
+    };
 
     ok(
         grep( {/all's well/i} @{ $tzil->log_messages } ),
@@ -57,7 +64,14 @@ local $ENV{AUTOMATED_TESTING};
     ok( $tzil, "created test dist" );
 
     local $ENV{AUTHOR_TESTING} = 1;
-    capture { $tzil->test };
+    try {
+        capture { $tzil->test };
+    }
+    catch {
+        my $err = $_;
+        fail( $err );
+        diag 'got log messages: ', explain $tzil->log_messages;
+    };
 
     ok(
         grep( {/all's well/i} @{ $tzil->log_messages } ),

--- a/t/runxt.t
+++ b/t/runxt.t
@@ -26,6 +26,7 @@ local $ENV{AUTOMATED_TESTING};
         { add_files => { 'source/xt/author/checkme.t' => $xt_fail, }, },
     );
     ok( $tzil, "created test dist" );
+    $tzil->chrome->logger->set_debug(1);
 
     try {
         capture { $tzil->test };
@@ -48,6 +49,7 @@ local $ENV{AUTOMATED_TESTING};
         { add_files => { 'source/xt/author/checkme.t' => $xt_fail, }, },
     );
     ok( $tzil, "created test dist" );
+    $tzil->chrome->logger->set_debug(1);
 
     local $ENV{AUTHOR_TESTING} = 1;
     try {
@@ -62,6 +64,7 @@ local $ENV{AUTOMATED_TESTING};
 {
     my $tzil = Dist::Zilla::Tester->from_config( { dist_root => 'corpus/RunXT' }, );
     ok( $tzil, "created test dist" );
+    $tzil->chrome->logger->set_debug(1);
 
     local $ENV{AUTHOR_TESTING} = 1;
     try {


### PR DESCRIPTION
non-perl files in `grep { -f } glob('xt/*')` are not executed, by using prove to examine those files in a separate pass before recursing into `grep { -d } glob('xt/*')`. closes #26.