### PR TITLE
replace Path::Iterator::Rule with File::Find::Rule (for 5.8)

### DIFF
--- a/lib/Dist/Zilla/App/Command/xtest.pm
+++ b/lib/Dist/Zilla/App/Command/xtest.pm
@@ -122,14 +122,14 @@ sub execute {
 
         my $app = App::Prove->new;
         if ( ref $arg eq 'ARRAY' && @$arg ) {
-            require Path::Iterator::Rule;
-            my $pcr = Path::Iterator::Rule->new->file->and(
+            require File::Find::Rule;
+            my $pcr = File::Find::Rule->new->file->exec(
                 sub {
-                    my $path = $_;
+                    my $path = $_[2];
                     return grep { $path =~ /$_/ } @$arg;
                 }
             );
-            my @t = map { "$_" } $pcr->all('xt');
+            my @t = map { "$_" } $pcr->in('xt');
             if (@t) {
                 $app->process_args( '-j', $opt->jobs, @v, qw/-r -b/, @t );
                 $error = "Failed xt tests" unless $app->run;


### PR DESCRIPTION
I love using Path::Iterator::Rule, but in this case it seems to be the only thing preventing [RunExtraTests] from being installable on 5.8. It's used for a very simple full-scan with no iterator, so using File::Find::Rule should be fine here. This functionality doesn't appear to be tested but I ran some `dzil xtest foobar` tests on my dists with a few regexes, including on 5.8.8, and it seems functional.
